### PR TITLE
Upgrade runtime and sdk

### DIFF
--- a/io.github.nearinfinitybrowser.nearinfinity.yml
+++ b/io.github.nearinfinitybrowser.nearinfinity.yml
@@ -1,9 +1,9 @@
 app-id: io.github.nearinfinitybrowser.nearinfinity
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.openjdk17
+  - org.freedesktop.Sdk.Extension.openjdk21
 command: nearinfinity
 
 finish-args:
@@ -22,7 +22,7 @@ modules:
   - name: openjdk
     buildsystem: simple
     build-commands:
-      - /usr/lib/sdk/openjdk17/install.sh
+      - /usr/lib/sdk/openjdk21/install.sh
 
   - name: nearinfinity
     buildsystem: simple


### PR DESCRIPTION
org.freedesktop.Platform: 22.08 -> 24.08
org.freedesktop.Sdk.Extension.openjdk: 17 -> 21